### PR TITLE
Add the ability to use element IDs in ?<element>

### DIFF
--- a/eod/handler.go
+++ b/eod/handler.go
@@ -23,6 +23,10 @@ func (b *EoD) cmdHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	if strings.HasPrefix(m.Content, "?") {
+		if strings.HasPrefix(m.Content, "?#") {
+			b.infoCmd(strings.TrimSpace(m.Content[1:]), true, strings.TrimSpace(m.content[2:]), msg, rsp)
+			return
+		}
 		b.infoCmd(strings.TrimSpace(m.Content[1:]), false, 0, msg, rsp)
 		return
 	}


### PR DESCRIPTION
This should make ?#<element ID number> give the element with the specified ID instead of the element with the name "#<element ID number>" if an element with the specified ID number exists.