### PR TITLE
Add poll notes to EoD Everywhere

### DIFF
--- a/eod/categories.go
+++ b/eod/categories.go
@@ -10,7 +10,7 @@ import (
 const x = "❌"
 const check = "✅"
 
-func (b *EoD) categoryCmd(elems []string, category string, m msg, rsp rsp) {
+func (b *EoD) categoryCmd(elems []string, category string, m msg, rsp rsp, pollNote string) {
 	lock.RLock()
 	dat, exists := b.dat[m.GuildID]
 	lock.RUnlock()
@@ -38,6 +38,9 @@ func (b *EoD) categoryCmd(elems []string, category string, m msg, rsp rsp) {
 		b.dat[m.GuildID] = dat
 		lock.Unlock()
 	}
+	if len(pollNote) == 0 {
+		pollNote = "None"
+	}
 	if len(suggestAdd) > 0 {
 		err := b.createPoll(poll{
 			Channel: dat.votingChannel,
@@ -45,6 +48,7 @@ func (b *EoD) categoryCmd(elems []string, category string, m msg, rsp rsp) {
 			Kind:    pollCategorize,
 			Value1:  category,
 			Value4:  m.Author.ID,
+			Value5:  pollNote,
 			Data:    map[string]interface{}{"elems": suggestAdd},
 		})
 		if rsp.Error(err) {
@@ -225,6 +229,9 @@ func (b *EoD) rmCategoryCmd(elems []string, category string, m msg, rsp rsp) {
 		b.dat[m.GuildID] = dat
 		lock.Unlock()
 	}
+	if len(pollNote) == 0 {
+		pollNote = "None"
+	}
 	if len(suggestRm) > 0 {
 		err := b.createPoll(poll{
 			Channel: dat.votingChannel,
@@ -232,6 +239,7 @@ func (b *EoD) rmCategoryCmd(elems []string, category string, m msg, rsp rsp) {
 			Kind:    pollUnCategorize,
 			Value1:  category,
 			Value4:  m.Author.ID,
+			Value5:  pollNote,
 			Data:    map[string]interface{}{"elems": suggestRm},
 		})
 		if rsp.Error(err) {

--- a/eod/pollcmds.go
+++ b/eod/pollcmds.go
@@ -109,7 +109,7 @@ func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp, pollNote string)
 		Value2:  mark,
 		Value3:  el.Comment,
 		Value4:  m.Author.ID,
-		Value5:  pollNote
+		Value5:  pollNote,
 	})
 	if rsp.Error(err) {
 		return

--- a/eod/pollcmds.go
+++ b/eod/pollcmds.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-func (b *EoD) suggestCmd(suggestion string, autocapitalize bool, m msg, rsp rsp) {
+func (b *EoD) suggestCmd(suggestion string, autocapitalize bool, m msg, rsp rsp, pollNote string) {
 	suggestion = strings.Replace(suggestion, "+", "", -1)
 	suggestion = strings.Replace(suggestion, "\\", "", -1)
 	suggestion = strings.TrimSpace(suggestion)
@@ -29,6 +29,11 @@ func (b *EoD) suggestCmd(suggestion string, autocapitalize bool, m msg, rsp rsp)
 	if dat.combCache == nil {
 		dat.combCache = make(map[string]comb)
 	}
+
+	if len(pollNote) == 0 {
+		pollNote = "None"
+	}
+
 	comb, exists := dat.combCache[m.Author.ID]
 	if !exists {
 		rsp.ErrorMessage("You haven't combined anything!")
@@ -53,6 +58,7 @@ func (b *EoD) suggestCmd(suggestion string, autocapitalize bool, m msg, rsp rsp)
 		Kind:      pollCombo,
 		Value3:    suggestion,
 		Value4:    m.Author.ID,
+		Value5:    pollNote,
 		Data:      map[string]interface{}{"elems": comb.elems},
 		Upvotes:   0,
 		Downvotes: 0,
@@ -72,7 +78,7 @@ func (b *EoD) suggestCmd(suggestion string, autocapitalize bool, m msg, rsp rsp)
 	rsp.Resp(txt)
 }
 
-func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp) {
+func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp, pollNote string) {
 	lock.RLock()
 	dat, exists := b.dat[m.GuildID]
 	lock.RUnlock()
@@ -91,6 +97,10 @@ func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp) {
 		return
 	}
 
+	if len(pollNote) == 0 {
+		pollNote = "None"
+	}
+
 	err := b.createPoll(poll{
 		Channel: dat.votingChannel,
 		Guild:   m.GuildID,
@@ -99,6 +109,7 @@ func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp) {
 		Value2:  mark,
 		Value3:  el.Comment,
 		Value4:  m.Author.ID,
+		Value5:  pollNote
 	})
 	if rsp.Error(err) {
 		return
@@ -106,7 +117,7 @@ func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp) {
 	rsp.Resp(fmt.Sprintf("Suggested a note for **%s** 🖊️", el.Name))
 }
 
-func (b *EoD) imageCmd(elem string, image string, m msg, rsp rsp) {
+func (b *EoD) imageCmd(elem string, image string, m msg, rsp rsp, pollNote string) {
 	lock.RLock()
 	dat, exists := b.dat[m.GuildID]
 	lock.RUnlock()
@@ -125,6 +136,10 @@ func (b *EoD) imageCmd(elem string, image string, m msg, rsp rsp) {
 		return
 	}
 
+	if len(pollNote) == 0 {
+		pollNote = "None"
+	}
+
 	err := b.createPoll(poll{
 		Channel: dat.votingChannel,
 		Guild:   m.GuildID,
@@ -133,6 +148,7 @@ func (b *EoD) imageCmd(elem string, image string, m msg, rsp rsp) {
 		Value2:  image,
 		Value3:  el.Image,
 		Value4:  m.Author.ID,
+		Value5:  pollNote,
 	})
 	if rsp.Error(err) {
 		return

--- a/eod/polls.go
+++ b/eod/polls.go
@@ -59,7 +59,7 @@ func (b *EoD) createPoll(p poll) error {
 			Title:       "Combination",
 			Description: txt + "\n\n" + "Suggested by <@" + p.Value4 + ">",
 			Footer: &discordgo.MessageEmbedFooter{
-				Text: "You can change your vote",
+				Text: fmt.Sprintf("Poll note: %s\n\nYou can change your vote", p.Value5),
 			},
 		})
 		if err != nil {
@@ -72,7 +72,7 @@ func (b *EoD) createPoll(p poll) error {
 			Title:       "Sign Note",
 			Description: fmt.Sprintf("**%s**\nNew Note: %s\n\nOld Note: %s\n\nSuggested by <@%s>", p.Value1, p.Value2, p.Value3, p.Value4),
 			Footer: &discordgo.MessageEmbedFooter{
-				Text: "You can change your vote",
+				Text: fmt.Sprintf("Poll note: %s\n\nYou can change your vote", p.Value5),
 			},
 		})
 		if err != nil {
@@ -85,7 +85,7 @@ func (b *EoD) createPoll(p poll) error {
 			Title:       "Add Image",
 			Description: fmt.Sprintf("**%s**\n[New Image](%s)\n[Old Image](%s)\n\nSuggested by <@%s>", p.Value1, p.Value2, p.Value3, p.Value4),
 			Footer: &discordgo.MessageEmbedFooter{
-				Text: "You can change your vote",
+				Text: fmt.Sprintf("Poll note: %s\n\nYou can change your vote", p.Value5),
 			},
 			Thumbnail: &discordgo.MessageEmbedThumbnail{
 				URL: p.Value2,
@@ -110,7 +110,7 @@ func (b *EoD) createPoll(p poll) error {
 			Title:       "Categorize",
 			Description: fmt.Sprintf("Elements:\n**%s**\n\nCategory: **%s**\n\nSuggested By <@%s>", strings.Join(p.Data["elems"].([]string), "\n"), p.Value1, p.Value4),
 			Footer: &discordgo.MessageEmbedFooter{
-				Text: "You can change your vote",
+				Text: fmt.Sprintf("Poll note: %s\n\nYou can change your vote", p.Value5),
 			},
 		})
 		if err != nil {
@@ -131,7 +131,7 @@ func (b *EoD) createPoll(p poll) error {
 			Title:       "Un-Categorize",
 			Description: fmt.Sprintf("Elements:\n**%s**\n\nCategory: **%s**\n\nSuggested By <@%s>", strings.Join(p.Data["elems"].([]string), "\n"), p.Value1, p.Value4),
 			Footer: &discordgo.MessageEmbedFooter{
-				Text: "You can change your vote",
+				Text: fmt.Sprintf("Poll note: %s\n\nYou can change your vote", p.Value5),
 			},
 		})
 		if err != nil {

--- a/eod/slashcmds.go
+++ b/eod/slashcmds.go
@@ -88,6 +88,12 @@ var (
 					Description: "Should the bot autocapitalize? Default: true",
 					Required:    false,
 				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "pollnote",
+					Description: "A note shown on the poll",
+					Required:    false,
+				},
 			},
 		},
 		{
@@ -106,6 +112,12 @@ var (
 					Description: "What the new creator mark should be!",
 					Required:    true,
 				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "pollnote",
+					Description: "A note shown on the poll",
+					Required:    false,
+				},
 			},
 		},
 		{
@@ -123,6 +135,12 @@ var (
 					Name:        "imageurl",
 					Description: "URL of an image to add to the element! You can also upload an image and then put the link here.",
 					Required:    true,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "pollnote",
+					Description: "A note shown on the poll",
+					Required:    false,
 				},
 			},
 		},
@@ -157,6 +175,12 @@ var (
 					Name:        "elem",
 					Description: "What element to add!",
 					Required:    true,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "pollnote",
+					Description: "A note shown on the poll",
+					Required:    false,
 				},
 				{
 					Type:        discordgo.ApplicationCommandOptionString,
@@ -335,6 +359,12 @@ var (
 				},
 				{
 					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "pollnote",
+					Description: "A note shown on the poll",
+					Required:    false,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
 					Name:        "elem2",
 					Description: "Another element to remove from the category!",
 					Required:    false,
@@ -385,13 +415,13 @@ var (
 			if len(i.Data.Options) > 1 {
 				autocapitalize = i.Data.Options[1].BoolValue()
 			}
-			bot.suggestCmd(i.Data.Options[0].StringValue(), autocapitalize, bot.newMsgSlash(i), bot.newRespSlash(i))
+			bot.suggestCmd(i.Data.Options[0].StringValue(), autocapitalize, bot.newMsgSlash(i), bot.newRespSlash(i), i.Data.Options[2].StringValue())
 		},
 		"mark": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			bot.markCmd(i.Data.Options[0].StringValue(), i.Data.Options[1].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i))
+			bot.markCmd(i.Data.Options[0].StringValue(), i.Data.Options[1].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i), i.Data.Options[2].StringValue())
 		},
 		"image": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-			bot.imageCmd(i.Data.Options[0].StringValue(), i.Data.Options[1].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i))
+			bot.imageCmd(i.Data.Options[0].StringValue(), i.Data.Options[1].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i), i.Data.Options[2].StringValue())
 		},
 		"inv": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			if len(i.Data.Options) > 0 {
@@ -405,12 +435,12 @@ var (
 		},
 		"addcat": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			suggestAdd := []string{i.Data.Options[1].StringValue()}
-			if len(i.Data.Options) > 2 {
-				for _, val := range i.Data.Options[2:] {
+			if len(i.Data.Options) > 3 {
+				for _, val := range i.Data.Options[3:] {
 					suggestAdd = append(suggestAdd, val.StringValue())
 				}
 			}
-			bot.categoryCmd(suggestAdd, i.Data.Options[0].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i))
+			bot.categoryCmd(suggestAdd, i.Data.Options[0].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i), i.Data.Options[2])
 		},
 		"cat": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			if len(i.Data.Options) == 0 {
@@ -452,12 +482,12 @@ var (
 		},
 		"rmcat": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 			suggestAdd := []string{i.Data.Options[1].StringValue()}
-			if len(i.Data.Options) > 2 {
-				for _, val := range i.Data.Options[2:] {
+			if len(i.Data.Options) > 3 {
+				for _, val := range i.Data.Options[3:] {
 					suggestAdd = append(suggestAdd, val.StringValue())
 				}
 			}
-			bot.rmCategoryCmd(suggestAdd, i.Data.Options[0].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i))
+			bot.rmCategoryCmd(suggestAdd, i.Data.Options[0].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i), i.Data.Options[2])
 		},
 	}
 )


### PR DESCRIPTION
poll notes show at the bottom of polls where the "You can change your vote" text normally appears. the "you can change your vote text" is moved to be two newlines after the poll note. hoping this works, i'm not very fluent in go