### PR TITLE
Add the +<element> alias from old EoD

### DIFF
--- a/eod/cmdhandlers.go
+++ b/eod/cmdhandlers.go
@@ -23,6 +23,17 @@ func (b *EoD) cmdHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
+	if strings.HasPrefix(m.Content, "+") {
+		if len(m.Content) < 2 {
+			return
+		}
+		suggestion := m.Content[1:]
+
+		suggestion = strings.TrimSpace(strings.ReplaceAll(suggestion, "\n", ""))
+		b.suggestCmd(suggestion, true, msg, rsp)
+		return
+	}
+
 	if strings.HasPrefix(m.Content, "!") {
 		if len(m.Content) < 2 {
 			return


### PR DESCRIPTION
+<element> should now act identically to !s <element>. This shouldn't cause any additional issues with the combo system as if a message gets to the +<element> part of the code it should never be processed by the combo system.