### PR TITLE
Add a character limit to creator marks

### DIFF
--- a/eod/pollcmds.go
+++ b/eod/pollcmds.go
@@ -31,6 +31,10 @@ func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp) {
 		rsp.ErrorMessage(fmt.Sprintf("Element **%s** is not in your inventory!", el.Name))
 		return
 	}
+	if len(mark) >= 1500 {
+		rsp.ErrorMessage("Creator marks must be under 1500 characters!")
+		return
+	}
 
 	if el.Creator == m.Author.ID {
 		b.mark(m.GuildID, elem, mark, "")

--- a/eod/pollcmds.go
+++ b/eod/pollcmds.go
@@ -31,8 +31,8 @@ func (b *EoD) markCmd(elem string, mark string, m msg, rsp rsp) {
 		rsp.ErrorMessage(fmt.Sprintf("Element **%s** is not in your inventory!", el.Name))
 		return
 	}
-	if len(mark) >= 1500 {
-		rsp.ErrorMessage("Creator marks must be under 1500 characters!")
+	if len(mark) >= 2400 {
+		rsp.ErrorMessage("Creator marks must be under 2400 characters!")
 		return
 	}
 


### PR DESCRIPTION
The character limit is 1000 which should make sure that creator marks don't cause any element info pages to go past the message character limit of 2000