### PR TITLE
[EoDE] Fix !cat not working when no argument is given

### DIFF
--- a/eod/cmdhandlers.go
+++ b/eod/cmdhandlers.go
@@ -151,9 +151,6 @@ func (b *EoD) cmdHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 
 		if cmd == "cat" {
-			if len(m.Content) <= len(cmd)+2 {
-				return
-			}
 			suggestion := m.Content[len(cmd)+2:]
 			suggestion = strings.TrimSpace(strings.ReplaceAll(suggestion, "\n", ""))
 

--- a/eod/cmdhandlers.go
+++ b/eod/cmdhandlers.go
@@ -153,6 +153,7 @@ func (b *EoD) cmdHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if cmd == "cat" {
 			if len(m.Content) <= len(cmd)+2 {
 				 bot.allCatCmd(catSortAlphabetical, msg, rsp) 
+				return
 			}
 			suggestion := m.Content[len(cmd)+2:]
 			suggestion = strings.TrimSpace(strings.ReplaceAll(suggestion, "\n", ""))

--- a/eod/cmdhandlers.go
+++ b/eod/cmdhandlers.go
@@ -151,6 +151,9 @@ func (b *EoD) cmdHandler(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 
 		if cmd == "cat" {
+			if len(m.Content) <= len(cmd)+2 {
+				 bot.allCatCmd(catSortAlphabetical, msg, rsp) 
+			}
 			suggestion := m.Content[len(cmd)+2:]
 			suggestion = strings.TrimSpace(strings.ReplaceAll(suggestion, "\n", ""))
 


### PR DESCRIPTION
The intended behavior is that when no argument is given, it opens the category list, however if no argument is given currently it does not process the command. This should fix it so that when no argument is given it instead tries to get the blank category, which cannot exist, thus redirecting it to the category list