### PR TITLE
Add info slash command

### DIFF
--- a/eod/slashcmds.go
+++ b/eod/slashcmds.go
@@ -699,6 +699,18 @@ var (
 				},
 			},
 		},
+		{
+			Name:        "info",
+			Description: "Get some information about an element!",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "element",
+					Description: "Name or ID of the element!",
+					Required:    true,
+				},
+			},
+		},
 	}
 	commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
 		"setnewschannel": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
@@ -978,6 +990,10 @@ var (
 				}
 			}
 			bot.catGraphCmd(catName, layout, outputType, special, bot.newMsgSlash(i), bot.newRespSlash(i))
+		},
+		"info": func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+			resp := i.ApplicationCommandData()
+			bot.infoCmd(resp.Options[0].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i))
 		},
 	}
 )


### PR DESCRIPTION
hoping this works because I just renamed a copy of the path command to info, changed the descriptions, and made it call the infoCmd function instead of the calcTreeCmd function with no other changes