### PR TITLE
Reduce creator mark length limit to 1024

### DIFF
--- a/eod/pollcmds.go
+++ b/eod/pollcmds.go
@@ -33,8 +33,8 @@ func (b *EoD) markCmd(elem string, mark string, m types.Msg, rsp types.Rsp) {
 		rsp.ErrorMessage(fmt.Sprintf("Element **%s** is not in your inventory!", el.Name))
 		return
 	}
-	if len(mark) >= 2400 {
-		rsp.ErrorMessage("Creator marks must be under 2400 characters!")
+	if len(mark) >= 1025 {
+		rsp.ErrorMessage("Creator marks are limited to 1024 characters!")
 		return
 	}
 


### PR DESCRIPTION
The field value length limit is 1024. If a creator mark is any longer, the info page of the element will not be able to be sent which defeats the entire purpose of the creator mark.