### PR TITLE
Replace empty marks with "None" during mark command

### DIFF
--- a/eod/polls/pollcmds.go
+++ b/eod/polls/pollcmds.go
@@ -36,6 +36,9 @@ func (b *Polls) MarkCmd(elem string, mark string, m types.Msg, rsp types.Rsp) {
 		rsp.ErrorMessage("Creator marks must be under 2400 characters!")
 		return
 	}
+	if len(strings.TrimSpace(mark)) <= 1 {
+		mark = "None"
+	}
 
 	if el.Creator == m.Author.ID {
 		b.mark(m.GuildID, elem, mark, "", "")


### PR DESCRIPTION
This is to prevent the issue of empty marks preventing an element from showing up and it would also just look better.