### PR TITLE
allow plus signs in element names

### DIFF
--- a/eod/elements/suggest.go
+++ b/eod/elements/suggest.go
@@ -10,7 +10,6 @@ import (
 )
 
 var invalidNames = []string{
-	"+",
 	"@everyone",
 	"@here",
 	"<@",


### PR DESCRIPTION
allow plus signs in element names (no longer breaks combos since combos no longer use element names)