### PR TITLE
Correctly pluralize values below 1

### DIFF
--- a/eod/polls/reactions.go
+++ b/eod/polls/reactions.go
@@ -26,10 +26,10 @@ func (b *Polls) RejectPoll(db *eodb.DB, p types.Poll, messageid, user string) {
 				if err == nil {
 					upvotes := ""
 					downvotes := ""
-					if p.Upvotes > 1 {
+					if p.Upvotes != 1 {
 						upvotes = "s"
 					}
-					if p.Downvotes > 1 {
+					if p.Downvotes != 1 {
 						downvotes = "s"
 					}
 


### PR DESCRIPTION
Previously, it only pluralized values greater than 1, but 0 is a possible number of upvotes for a poll, and a zero amount should be pluralized in English.

also pull request #69, nice