### PR TITLE
Replaced colour with tree size

### DIFF
--- a/eod/elements/info.go
+++ b/eod/elements/info.go
@@ -288,7 +288,7 @@ func (b *Elements) Info(elem string, id int, isId bool, m types.Msg, rsp types.R
 		{Name: db.Config.LangProperty("InfoComment"), Value: shortcomment, Inline: false},
 		{Name: db.Config.LangProperty("InfoCreator"), Value: fmt.Sprintf("<@%s>", el.Creator), Inline: true},
 		{Name: db.Config.LangProperty("InfoCreateTime"), Value: createdOn, Inline: true},
-		{Name: db.Config.LangProperty("InfoColor"), Value: util.FormatHex(el.Color), Inline: true},
+		{Name: db.Config.LangProperty("InfoTreeSize"), Value: strconv.Itoa(tree.Total), Inline: true},
 	}
 
 	// Get whether has element


### PR DESCRIPTION
Currently the collapsed info displays the colour as text, which is completely redundant as the colour is already shown on the left. This replaces it with the much more commonly used tree size, as evidenced by the discussion here on the EoD Server https://discord.com/channels/705084182673621033/936702705668325386/936703017552609350