### PR TITLE
allow the formatting of BigInts larger than 1.8e308

### DIFF
--- a/eod/util/format.go
+++ b/eod/util/format.go
@@ -82,6 +82,5 @@ func FormatBigInt(b *big.Int) string {
 
 	// Get number of digits
 	f := big.NewFloat(0).SetInt(b)
-	v, _ := f.Float64()
-	return fmt.Sprintf("%v", v)
+	return fmt.Sprintf("%v", f)
 }


### PR DESCRIPTION
for some reason it was converting it to float64s completely unnecessarily, sprintf works with big floats just fine