### PR TITLE
Fix /image url crashing after completing command

### DIFF
--- a/eod/slashcmds.go
+++ b/eod/slashcmds.go
@@ -1681,6 +1681,7 @@ var (
 
 			if resp.Name == "url" {
 				bot.polls.ImageCmd(resp.Options[0].StringValue(), resp.Options[1].StringValue(), bot.newMsgSlash(i), bot.newRespSlash(i))
+				return
 			}
 
 			// Get attachment


### PR DESCRIPTION
/image url would continue doing the attachment getting code after it finished doing the actual /image command which broke it because /image url doesn't have an attachment argument, i added a return statement so it shouldn't do that anymore