### PR TITLE
Do not replace ` with ', as ` is a different key

### DIFF
--- a/eod/elements/suggest.go
+++ b/eod/elements/suggest.go
@@ -20,7 +20,6 @@ var invalidNames = []string{
 var charReplace = map[rune]rune{
 	'’': '\'',
 	'‘': '\'',
-	'`': '\'',
 	'”': '"',
 	'“': '"',
 }


### PR DESCRIPTION
No one uses it as a normal apostrophe