### PR TITLE
Patch instant-vote bug

### DIFF
--- a/eod/polls/handle.go
+++ b/eod/polls/handle.go
@@ -35,17 +35,17 @@ func (b *Polls) reactionHandler(s *discordgo.Session, r *discordgo.MessageReacti
 		return
 	}
 
-	// User trying to delete?
-	if r.UserID == p.Creator && r.Emoji.Name == DownArrow {
-		b.deletePoll(&p, s)
-		return
-	}
-
 	// Handle
 	if r.Emoji.Name == UpArrow {
 		p.Upvotes++
 	} else {
 		p.Downvotes++
+	}
+	
+	// User trying to delete?
+	if r.UserID == p.Creator && r.Emoji.Name == DownArrow {
+		b.deletePoll(&p, s)
+		return
 	}
 
 	// Update


### PR DESCRIPTION
Prevents a bug that allows the suggester of an element to down-vote then quickly remove their down-vote, leading to the element getting voted in at one below the required number