### PR TITLE
bug fix

### DIFF
--- a/eod/categories/infoedit.go
+++ b/eod/categories/infoedit.go
@@ -55,7 +55,7 @@ func (c *Categories) MsgSignCmd(ctx sevcord.Ctx, cat string, mark string) {
 	err := c.db.QueryRow("SELECT name, comment FROM categories WHERE LOWER(name)=$1 AND guild=$2", strings.ToLower(cat), ctx.Guild()).Scan(&name, &old)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			ctx.Respond(sevcord.NewMessage("Element **" + cat + "** doesn't exist! " + types.RedCircle))
+			ctx.Respond(sevcord.NewMessage("Category **" + cat + "** doesn't exist! " + types.RedCircle))
 			return
 		} else {
 			c.base.Error(ctx, err)

--- a/eod/msgs.go
+++ b/eod/msgs.go
@@ -246,7 +246,7 @@ func (b *Bot) textCommandHandler(c sevcord.Ctx, name string, content string) {
 		if len(parts) == 2 {
 			prefixSplit = strings.SplitN(parts[0], " ", 2)
 		}
-		if len(prefixSplit) == 1 {
+		if len(prefixSplit) == 1 || strings.TrimSpace(prefixSplit[1]) == "" {
 			// assume signing element
 			b.elements.MsgSignCmd(c, strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
 			return
@@ -285,9 +285,9 @@ func (b *Bot) textCommandHandler(c sevcord.Ctx, name string, content string) {
 		var prefixSplit []string
 		if len(parts) == 2 {
 			// split args before hex code to determine existence of first arg
-			prefixSplit = strings.SplitN(content, " ", 2)
+			prefixSplit = strings.SplitN(parts[0], " ", 2)
 		}
-		if len(prefixSplit) == 1 {
+		if len(prefixSplit) == 1 || strings.TrimSpace(prefixSplit[1]) == "" {
 			// no second arg, assume first arg is the element
 			var item = strings.TrimSpace(strings.Split(prefixSplit[0], "|")[0])
 			id, ok := b.getElementId(c, item)


### PR DESCRIPTION
Fixing issue where adding spaces after the word "Category" makes the game incorrectly attempt to mark or color the category "". Making marking nonexistent category say "Category name doesn't exist" instead of "Element name doesn't exist"